### PR TITLE
Quick patch: serialise object in WebSocket node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "plotty",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/src/lib/standard-library/components/data/websocket.ts
+++ b/src/lib/standard-library/components/data/websocket.ts
@@ -77,9 +77,20 @@ const c: PlottyComponent = {
         }
 
         if (input.hasData('in')) {
-            const data = input.getData('in');
+            let data = input.getData('in');
 
-            // TODO handle serialisation
+            // If object, serialise to JSON
+            switch (typeof data) {
+                case 'number':
+                    // Send as a string representation
+                    data = data.toString();
+                    break;
+
+                case 'object':
+                    // Convert objects as JSON (not pretty-printed)
+                    data = JSON.stringify(data);
+                    break;
+            }
 
             // Send to websocket
             sendToWebsocket(context.nodeInstance.state, data);


### PR DESCRIPTION
Currently objects are implicitly sent as `[Object]`. The default behaviour should be to serialise unless explicitly told not to